### PR TITLE
Make sure the limiter_map is populated

### DIFF
--- a/UWGeodynamics/_model.py
+++ b/UWGeodynamics/_model.py
@@ -2237,7 +2237,7 @@ class _ViscosityFunction():
                 minViscosity = material.minViscosity
             if material.maxViscosity:
                 maxViscosity = material.maxViscosity
-            limiter = Viscosity_limiter(eta, minViscosity, maxViscosity)
+            limiter_map[material.index] = Viscosity_limiter(eta, minViscosity, maxViscosity)
 
         if limiter_map:
             return fn.branching.map(fn_key=Model.materialField,


### PR DESCRIPTION
The `limiter` variable was not being used, so `material.[min|max]Viscosity` were not being applied.

This fix adds each material to the `limiter_map` dict.